### PR TITLE
fix: wrap npx in cmd.exe /c on Windows to fix ProcessNotCreatedException

### DIFF
--- a/src/main/kotlin/likec4/plugin/lsp/LikeC4LspServerDescriptor.kt
+++ b/src/main/kotlin/likec4/plugin/lsp/LikeC4LspServerDescriptor.kt
@@ -1,7 +1,9 @@
 package likec4.plugin.lsp
 
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.configurations.GeneralCommandLine.ParentEnvironmentType
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
@@ -43,10 +45,15 @@ class LikeC4LspServerDescriptor(project: Project) : ProjectWideLspServerDescript
     }
     override fun isSupportedFile(file: VirtualFile) = LikeC4LspServerDescriptor.isSupportedFile(file)
 
-    override fun createCommandLine(): GeneralCommandLine =
-        GeneralCommandLine("npx")
-            .withParameters("@likec4/lsp", "--yes", "--stdio")
-            .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
+    override fun createCommandLine(): GeneralCommandLine {
+        val baseCommand = listOf("npx", "@likec4/lsp", "--yes", "--stdio")
+        val commandLine = if (SystemInfo.isWindows) {
+            GeneralCommandLine("cmd.exe", "/c").withParameters(baseCommand)
+        } else {
+            GeneralCommandLine(baseCommand)
+        }
+        return commandLine.withParentEnvironmentType(ParentEnvironmentType.CONSOLE)
+    }
 
 //    override val lspCommunicationChannel = LspCommunicationChannel.Socket(11233)
 


### PR DESCRIPTION
Was running into following error constantly under Windows (I am using WSL):
>  com.intellij.execution.process.ProcessNotCreatedException: Cannot run program "npx":
      CreateProcess error=2, The system cannot find the file specified


Fixed by applying the Windows cmd wrapping introduced in `LikeC4LanguageServerInstaller.kt` (31873b3f62d0b41b1f65e56bc1a33bfa937eafef) to `GeneralCommandLine` in `LikeC4LspServerDescriptor.kt`.

Fixes the mentioned error when opening `.c4` files in the IDE. I retried with plugin built from my fork and the error does not occur anymore.
